### PR TITLE
Add default for the setting #xdStoredPlaygroundsDirectory

### DIFF
--- a/src/XDoc-Store/XdPlaygroundSettings.class.st
+++ b/src/XDoc-Store/XdPlaygroundSettings.class.st
@@ -60,6 +60,7 @@ XdPlaygroundSettings class >> storedPlaygroundsDirectoryOn: aBuilder [
 		parent: #xdoc;
 		target: self;
 		type: #Directory;
+		default: self defaultDirectory;
 		description: 'Local directory with stored Playgrounds in XDoc format';
 		label: 'Directory with stored Playgrounds'
 


### PR DESCRIPTION
This pull request adds a default for the setting `#xdStoredPlaygroundsDirectory` to avoid an infinite loop in which `#settingValueChanged:` is repeatedly sent due to `#realValue` sending `#setToDefault` which sends `#realValue:` with nil as the argument.

This fixes: https://github.com/feenkcom/gtoolkit/issues/3616
